### PR TITLE
Hack to fix broken assign reviewers page

### DIFF
--- a/app/assets/javascripts/components/admin/reviewers_page/cohort_reviewers/AdminCohortReviewerSearch.js.jsx
+++ b/app/assets/javascripts/components/admin/reviewers_page/cohort_reviewers/AdminCohortReviewerSearch.js.jsx
@@ -22,7 +22,7 @@ class AdminCohortReviewerSearch extends React.Component {
   }
 
   filteredSearch() {
-    let search = this.state.search.toLowerCase()
+    let search = (this.state.search || "").toLowerCase()
     let length = search.length
 
     return this.props.cohort.non_reviewers.filter((reviewer) => {


### PR DESCRIPTION
Why:

* the assign reviewers page was broken on production because
  `this.state.search` was null for some reason. It worked locally and on
  staging.

This change addresses the need by:

* this fix puts in a hack to fallback to empty string, which should not
  be necessary but appears to be for some reason. Let's see if this
  change fixes it

https://trello.com/c/0jWyUrQc/298-fix-assign-reviewers-page