### PR TITLE
Actually fix reviewer assign page

### DIFF
--- a/app/assets/javascripts/components/admin/reviewers_page/cohort_reviewers/AdminCohortReviewerSearch.js.jsx
+++ b/app/assets/javascripts/components/admin/reviewers_page/cohort_reviewers/AdminCohortReviewerSearch.js.jsx
@@ -22,11 +22,11 @@ class AdminCohortReviewerSearch extends React.Component {
   }
 
   filteredSearch() {
-    let search = (this.state.search || "").toLowerCase()
+    let search = this.state.search.toLowerCase()
     let length = search.length
 
     return this.props.cohort.non_reviewers.filter((reviewer) => {
-      return (reviewer.name.toLowerCase().substr(0, length) == search)
+      return ((reviewer.name || "").toLowerCase().substr(0, length) == search)
     })
   }
 


### PR DESCRIPTION
Why:

* fast follow undoing 788f4be33ad66fe752f96e0a45669de4e6c9ccab and
  adding a different hack / fallback

This change addresses the need by:

* to make sure the `reviewer.name` is not null

https://trello.com/c/0jWyUrQc/298-fix-assign-reviewers-page