### PR TITLE
add provider to user in seed file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,7 +100,7 @@ class Seed
       uid = (1234 + i).to_s
       token = (9876543 + i).to_s
 
-      User.create(name: name, email: email, uid: uid, token: token)
+      user = User.create!(name: name, email: email, uid: uid, token: token, provider: 'github')
     end
   end
 
@@ -111,7 +111,7 @@ class Seed
       uid = (12345 + i).to_s
       token = (98765432 + i).to_s
 
-      User.create(name: name, email: email, uid: uid, token: token)
+      User.create(name: name, email: email, uid: uid, token: token, provider: 'github')
     end
   end
 
@@ -122,7 +122,7 @@ class Seed
       uid = (123456 + i).to_s
       token = (987654321 + i).to_s
 
-      User.create(name: name, email: email, uid: uid, token: token, role: 'reviewer')
+      User.create(name: name, email: email, uid: uid, token: token, role: 'reviewer', provider: 'github')
     end
   end
 


### PR DESCRIPTION
@VictoriaVasys @srt32 I came across an issue when trying to seed the repo. It looks like provider was added to users and updated the currently seeded information but the `seeds.rb` was not updated. I was making the assumption based on migrations that the provider for all seeded users was github but I might be wrong. I made the change in the seed file so merge if this is correct!