### PR TITLE
Properly persist Census user name

### DIFF
--- a/app/models/concerns/oauth_user.rb
+++ b/app/models/concerns/oauth_user.rb
@@ -6,7 +6,7 @@ module OauthUser
       {
         uid: params['uid'],
         token: params['credentials']['token'],
-        name: params['info']['name'],
+        name: [params['info']['first_name'], params['info']['last_name']].join(" "),
         email: params['info']['email']
       }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe User do
           'uid' => '90210',
           'credentials' => { 'token' => 'averysecrettoken' },
           'info' => {
-            'name' => 'John Galt',
+            'first_name' => 'John',
+            'last_name' => 'Galt',
             'email' => 'somewhere@colorado.com',
             'roles' => roles.map { |role| { 'name' => role } }
           },
@@ -88,7 +89,8 @@ RSpec.describe User do
           'uid' => '90210',
           'credentials' => { 'token' => 'averysecrettoken' },
           'info' => {
-            'name' => 'John Galt',
+            'first_name' => 'John',
+            'last_name' => 'Galt',
             'email' => 'somewhere@colorado.com'
           },
           'provider' => User::AUTH_PROVIDER_GITHUB


### PR DESCRIPTION
Why:

* we were not getting the user from Census properly.

This change addresses the need by:

* updating the oauth mapping to take the first / last name and combine
  it into a single name and then storing it.

https://trello.com/c/PR2Vk9pC/381-make-name-required-in-the-census-sign-up-form