### PR TITLE
Show total average for applications on admin dashboard

### DIFF
--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplications.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplications.js.jsx
@@ -11,7 +11,7 @@ class AdminCohortApplications extends React.Component {
           width='100%'/>
 
         <AdminCohortApplicationList
-          applications={this.props.cohort.applications_by_state_and_id}
+          applications={sortedWithReviewCount(this.props.cohort.applications)}
           handleAction={this.props.handleAction} />
 
       </section>

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplicationsList.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplicationsList.js.jsx
@@ -6,7 +6,7 @@ class AdminCohortApplicationList extends React.Component {
         {this.props.applications.map((app) => {
           return <SelectableTextField
             key={app.user.id}
-            texts={[app.id, app.user.email, app.state]}
+            texts={[`${app.totalAverage || 0} (${app.numberOfReviews}/${app.reviews.length})`, app.user.email, app.state]}
             width='100%'
             returnKey='application'
             returnValue={app}

--- a/app/assets/javascripts/helpers/application.js.jsx
+++ b/app/assets/javascripts/helpers/application.js.jsx
@@ -3,7 +3,7 @@ function sortedWithReviewCount(applications) {
   return appsWithScore.sort((a,b) => {
     if ((a.state === "draft" && b.state === "submitted") || a.numberOfReviews < b.numberOfReviews) {
       return 1;
-    } else if (a.numberOfReviews > b.numberOfReviews) {
+    } else if ((a.state === "submitted" && b.state === "draft") || a.numberOfReviews > b.numberOfReviews) {
       return -1;
     } else {
       return b.totalAverage - a.totalAverage

--- a/app/assets/javascripts/helpers/application.js.jsx
+++ b/app/assets/javascripts/helpers/application.js.jsx
@@ -1,0 +1,26 @@
+function sortedWithReviewCount(applications) {
+  appsWithScore = applications.map(application => Object.assign(application, scoreAndReviewers(application)))
+  return appsWithScore.sort((a,b) => {
+    if ((a.state === "draft" && b.state === "submitted") || a.numberOfReviews < b.numberOfReviews) {
+      return 1;
+    } else if (a.numberOfReviews > b.numberOfReviews) {
+      return -1;
+    } else {
+      return b.totalAverage - a.totalAverage
+    }
+  })
+}
+
+function scoreAndReviewers(application) {
+  let numberOfReviews = 0;
+  let totalSum = 0;
+
+  application.reviews.forEach(review => {
+    if (review.status === "reviewed") {
+      numberOfReviews++
+      totalSum += review.score_card.total
+    }
+  })
+
+  return {numberOfReviews, totalAverage: parseFloat((totalSum/numberOfReviews).toFixed(2))}
+}

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < AdminController
 
   def index
-    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews]}}, :reviewers, :non_reviewers, :applications_by_state_and_id => {:include => [:user, :reviews]}], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
+    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews]}}, :reviewers, :non_reviewers], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
     @users = User.all.to_json
     @user = current_user
     @authorization = JwToken.encode({user_id: current_user.id})

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -12,10 +12,6 @@ class Cohort < ApplicationRecord
   scope :current, -> { where('open_date <= ? AND close_date >= ?', Date.today, Date.today) }
   scope :closed, -> { where('open_date > ? OR close_date < ?', Date.today, Date.today) }
 
-  def applications_by_state_and_id
-    applications.order('state DESC, id')
-  end
-
   def reviewers
     users.where(role: 'reviewer')
   end


### PR DESCRIPTION
Card: https://trello.com/c/HnlnmmtC/465-full-circle-avg-total-score-on-the-index-view

Before Erin had to individual click into every application and keep track of the total for each applicant. Now we show the applicants sorted by total average along with the number of reviews. 

<img width="509" alt="screen shot 2018-10-17 at 5 55 03 pm" src="https://user-images.githubusercontent.com/1551316/47099562-d5fc9500-d235-11e8-90de-7c281c5481f1.png">


Note: An assumption is made that "draft" applications will not be reviewed

Removed `applications_by_state_and_id` as this sorting should be done on the front end and we updated the sort.