### PR TITLE
Add checked for locked reviews when calculating totals

### DIFF
--- a/app/assets/javascripts/helpers/application.js.jsx
+++ b/app/assets/javascripts/helpers/application.js.jsx
@@ -16,7 +16,7 @@ function scoreAndReviewers(application) {
   let totalSum = 0;
 
   application.reviews.forEach(review => {
-    if (review.status === "reviewed") {
+    if (review.status === "reviewed" || review.status === "locked") {
       numberOfReviews++
       totalSum += review.score_card.total
     }


### PR DESCRIPTION
I noticed when checking production that reviews can also be in a 'locked' status. We should take these reviews into account when showing the data as well.