### PR TITLE
Add 'View Reviewers' button to show status of reviews

### DIFF
--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
@@ -1,5 +1,13 @@
 class AdminApplicationActionBar extends React.Component {
 
+  showReviewers() {
+    let reviewersStatuses = this.props.application.reviews.map(review => {
+      return `${review.cohort_reviewer.user.email} - ${review.status}`
+    })
+
+    alert(reviewersStatuses.join('\n'))
+  }
+
   render() {
     return(
       <section className='application-action-bar'>
@@ -14,9 +22,9 @@ class AdminApplicationActionBar extends React.Component {
           onClick={this.props.handleAction} />
 
         <ClickBtn
-          readOnly='flag-btn'
-          Text={'Flag'}
-          onClick={this.props.handleAction} />
+          readOnly='reviewers-btn'
+          Text={'View Reviewers'}
+          onClick={this.showReviewers.bind(this)} />
 
       </section>
     )

--- a/app/assets/stylesheets/modules/admin/view_cohorts_page/_application_action_bar.scss
+++ b/app/assets/stylesheets/modules/admin/view_cohorts_page/_application_action_bar.scss
@@ -6,24 +6,23 @@
     width: 100%;
 
     @include btn();
-    
+
     .btn {
       margin: 0px 5px;
       font-size: 12px;
       height: 25px;
-      max-width: 60px;
     }
-    
+
     .decline-btn {
       background-color: #dc143c;
     }
-    
+
     .award-btn {
       background-color: #60eba8;
     }
-    
-    .flag-btn {
-      background-color: #d5d622;
+
+    .reviewers-btn {
+      background-color: #00bbd2;
     }
   }
 }

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < AdminController
 
   def index
-    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews]}}, :reviewers, :non_reviewers], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
+    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews => {:include => [:cohort_reviewer => {:include => :user}]}]}}, :reviewers, :non_reviewers], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
     @users = User.all.to_json
     @user = current_user
     @authorization = JwToken.encode({user_id: current_user.id})


### PR DESCRIPTION
Trello Card:
https://trello.com/c/IBFp3aWU/516-add-ability-to-see-who-hasnt-reviewed-an-application-yet

Currently there is not an easy way to see who has and has not reviewed a particular application. This adds a button and an alert (albeit ugly) to show reviewer's emails and their review status on the application.

<img width="326" alt="screen shot 2018-10-22 at 6 06 02 pm" src="https://user-images.githubusercontent.com/1551316/47303793-2e140c80-d625-11e8-8c17-02e419b3f1fb.png">
<img width="470" alt="screen shot 2018-10-22 at 6 06 06 pm" src="https://user-images.githubusercontent.com/1551316/47303800-33715700-d625-11e8-8c97-c78c60012336.png">
