### PR TITLE
Link award/decline buttons to update state and send email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@
 /app/channels
 /app/helpers
 /app/jobs
-/app/mailers
 
 /config/locales
 /vendor

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Description: **Creates a clickable button that will execute a function.** <br>
 Props:
  - onClick: (Function) What will be executed on button click.
  - Text: (String) Text that will be displayed in button body.
- - readOnly: (Boolean) Defaults to false. True will disable button.
+ - readOnly: (String) Classnames. 'true' class will hide button.
+ - disabled: (Boolean) Defaults to false. `true` will disable the button as clickable.
 
 Name: **LinkBtn** <br>
 Description: **Creates a clickable button that will reroute to a link.** <br>

--- a/app/assets/javascripts/components/admin/view_cohorts_page/adminViewCohorts.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/adminViewCohorts.js.jsx
@@ -21,7 +21,7 @@ class AdminViewCohorts extends React.Component {
         cohorts: cohorts,
         item: cohort,
         applications: cohort.applications,
-        application: cohort.applications[0]
+        application: sortedWithReviewCount(cohort.applications)[0]
       })
     }
   }
@@ -42,7 +42,7 @@ class AdminViewCohorts extends React.Component {
       </section>
     }
   }
-  
+
   render() {
     return(
       <section className='main-horz-frame'>

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
@@ -7,7 +7,7 @@ class AdminApplicationActionBar extends React.Component {
 
     alert(reviewersStatuses.join('\n'))
   }
-  
+
   updateStatus(status) {
     this.props.application.status = status
     const options = {
@@ -16,20 +16,21 @@ class AdminApplicationActionBar extends React.Component {
       headers: { 'Authorization': this.props.authorization,
       'Content-Type': "application/json" }}
 
-      ping(`/api/v1/admin/applications/${this.props.application.id}`, options)
-      .then(response => {
-        response.json().then((json) => {
-          this.props.handleAction({
-            application: json,
-            message: 'Application status updated'
-          })
-        })
-      })
-      .catch((error) => {
+    ping(`/api/v1/admin/applications/${this.props.application.id}`, options)
+    .then(response => {
+      response.json().then((json) => {
         this.props.handleAction({
-          message: 'Unable to edit application status'
+          application: json,
+          message: 'Application status updated'
         })
       })
+    })
+    .catch((error) => {
+      this.props.handleAction({
+        message: 'Unable to edit application status'
+      })
+    })
+  }
 
   render() {
     return(

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
@@ -7,6 +7,29 @@ class AdminApplicationActionBar extends React.Component {
 
     alert(reviewersStatuses.join('\n'))
   }
+  
+  updateStatus(status) {
+    this.props.application.status = status
+    const options = {
+      method: 'PUT',
+      body: JSON.stringify({application: this.props.application}),
+      headers: { 'Authorization': this.props.authorization,
+      'Content-Type': "application/json" }}
+
+      ping(`/api/v1/admin/applications/${this.props.application.id}`, options)
+      .then(response => {
+        response.json().then((json) => {
+          this.props.handleAction({
+            application: json,
+            message: 'Application status updated'
+          })
+        })
+      })
+      .catch((error) => {
+        this.props.handleAction({
+          message: 'Unable to edit application status'
+        })
+      })
 
   render() {
     return(
@@ -14,12 +37,12 @@ class AdminApplicationActionBar extends React.Component {
         <ClickBtn
           readOnly='decline-btn'
           Text={'Decline'}
-          onClick={this.props.handleAction} />
+          onClick={() => this.updateStatus('declined')} />
 
         <ClickBtn
           readOnly='award-btn'
           Text={'Award'}
-          onClick={this.props.handleAction} />
+          onClick={() => this.updateStatus('awarded')} />
 
         <ClickBtn
           readOnly='reviewers-btn'

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
@@ -1,5 +1,13 @@
 class AdminApplicationActionBar extends React.Component {
 
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      sendingStatus: false,
+    }
+  }
+
   showReviewers() {
     let reviewersStatuses = this.props.application.reviews.map(review => {
       return `${review.cohort_reviewer.user.email} - ${review.status}`
@@ -9,7 +17,10 @@ class AdminApplicationActionBar extends React.Component {
   }
 
   updateStatus(status) {
+    this.setState({sendingStatus: true})
+
     this.props.application.status = status
+
     const options = {
       method: 'PUT',
       body: JSON.stringify({application: this.props.application}),
@@ -30,6 +41,17 @@ class AdminApplicationActionBar extends React.Component {
         message: 'Unable to edit application status'
       })
     })
+    .finally(() => {
+      this.setState({sendingStatus: false})
+    })
+  }
+
+  awardScholarship() {
+    this.updateStatus('awarded')
+  }
+
+  declineScholarship() {
+    this.updateStatus('declined')
   }
 
   render() {
@@ -37,13 +59,15 @@ class AdminApplicationActionBar extends React.Component {
       <section className='application-action-bar'>
         <ClickBtn
           readOnly='decline-btn'
+          disabled={this.state.sendingStatus}
           Text={'Decline'}
-          onClick={() => this.updateStatus('declined')} />
+          onClick={this.declineScholarship.bind(this)} />
 
         <ClickBtn
           readOnly='award-btn'
+          disabled={this.state.sendingStatus}
           Text={'Award'}
-          onClick={() => this.updateStatus('awarded')} />
+          onClick={this.awardScholarship.bind(this)} />
 
         <ClickBtn
           readOnly='reviewers-btn'

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminViewApplicationSection.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminViewApplicationSection.js.jsx
@@ -5,9 +5,13 @@ class AdminViewApplicationSection extends React.Component {
       <section className='view-applications'>
         <h4 className='reviewer-header'>{this.props.application.user.alt_name}'s Application</h4>
         <h5>{this.props.application.user.alt_name.split(' ')[0]}'s Email: {this.props.application.user.email}</h5>
-        <AdminApplicationActionBar
-          application={this.props.application}
-          handleAction={this.props.handleAction} />
+        { this.props.application.status === "undecided" ? (
+          <AdminApplicationActionBar
+            application={this.props.application}
+            handleAction={this.props.handleAction} />
+        ) : (
+          <h5>Status: {this.props.application.status}</h5>
+        )}
 
         <AdminAppDataSection
           application={this.props.application} />

--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminViewApplicationSection.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminViewApplicationSection.js.jsx
@@ -8,7 +8,8 @@ class AdminViewApplicationSection extends React.Component {
         { this.props.application.status === "undecided" ? (
           <AdminApplicationActionBar
             application={this.props.application}
-            handleAction={this.props.handleAction} />
+            handleAction={this.props.handleAction}
+            authorization={this.props.authorization}/>
         ) : (
           <h5>Status: {this.props.application.status}</h5>
         )}

--- a/app/assets/javascripts/components/shared/clickBtn.js.jsx
+++ b/app/assets/javascripts/components/shared/clickBtn.js.jsx
@@ -1,9 +1,10 @@
 class ClickBtn extends React.Component {
 
   render() {
+    const onClick = this.props.disabled ? false : this.props.onClick
     return(
-      <div className={['btn', this.props.readOnly].join(' ').trim()}
-        onClick={this.props.onClick}>
+      <div className={['btn', this.props.readOnly, this.props.disabled ? 'disabled' : ''].join(' ').trim()}
+        onClick={onClick}>
         {this.props.Text}
       </div>
     )

--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -26,6 +26,16 @@
     visibility: visible;
   }
 
+  .btn.disabled {
+    background-color: $turing-gray;
+    cursor: not-allowed;
+  }
+
+  .btn.disabled:active {
+    background-color: $turing-gray;
+    cursor: not-allowed;
+  }
+
   .btn:hover {
     @include shadow();
   }

--- a/app/controllers/api/v1/admin/applications_controller.rb
+++ b/app/controllers/api/v1/admin/applications_controller.rb
@@ -7,4 +7,19 @@ class Api::V1::Admin::ApplicationsController < Api::V1::AdminApiController
                    }
   end
 
+  def update
+    application = Application.find(params[:id])
+
+    if application.update(application_params)
+      render json: application, status: 200
+    else
+      render json: { "error" => "Error Updating Application" }, status: 400
+    end
+  end
+
+  private
+    def application_params
+      params.require(:application)
+        .permit(:status)
+    end
 end

--- a/app/controllers/api/v1/admin/applications_controller.rb
+++ b/app/controllers/api/v1/admin/applications_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Admin::ApplicationsController < Api::V1::AdminApiController
     application = Application.find(params[:id])
 
     if application.update(application_params)
-      render json: application, status: 200
+      render json: application, :include => [:user, :reviews], status: 200
     else
       render json: { "error" => "Error Updating Application" }, status: 400
     end

--- a/app/controllers/api/v1/admin/applications_controller.rb
+++ b/app/controllers/api/v1/admin/applications_controller.rb
@@ -11,6 +11,9 @@ class Api::V1::Admin::ApplicationsController < Api::V1::AdminApiController
     application = Application.find(params[:id])
 
     if application.update(application_params)
+      if application_params[:status] && ['declined', 'awarded'].include?(application_params[:status])
+        ApplicationStatusMailer.notify(application).deliver_now
+      end
       render json: application, :include => [:user, :reviews], status: 200
     else
       render json: { "error" => "Error Updating Application" }, status: 400

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,4 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: 'contact@turing.io'
+  layout 'mailer'
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'contact@turing.io'
+  default from: '"Turing School" <contact@turing.io>'
   layout 'mailer'
 end

--- a/app/mailers/application_status_mailer.rb
+++ b/app/mailers/application_status_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationStatusMailer < ApplicationMailer
+
+  def award(application)
+    @application = application
+
+    mail(to: application.user.email, subject: 'Congratulation')
+  end
+
+  def decline(application)
+    @application = application
+
+    mail(to: application.user.email, subject: 'Diversity Scholarship')
+  end
+end

--- a/app/mailers/application_status_mailer.rb
+++ b/app/mailers/application_status_mailer.rb
@@ -3,15 +3,12 @@ class ApplicationStatusMailer < ApplicationMailer
   def notify(application)
     @application = application
 
-    if application.status == 'awarded'
-      mail(to: application.user.email,
-           subject: 'Congratulation',
-           template_name: 'award')
-    else
-      mail(to: application.user.email,
-           subject: 'Diversity Scholarship',
-           template_name: 'decline')
-    end
+    mail(
+        to: @application.user.email,
+        bcc: "contact@turing.io",
+        subject: "Turing School Scholarship Application",
+        template_name: application.status == 'awarded' ? "award" : "decline"
+        )
   end
 
 end

--- a/app/mailers/application_status_mailer.rb
+++ b/app/mailers/application_status_mailer.rb
@@ -1,14 +1,17 @@
 class ApplicationStatusMailer < ApplicationMailer
 
-  def award(application)
+  def notify(application)
     @application = application
 
-    mail(to: application.user.email, subject: 'Congratulation')
+    if application.status == 'awarded'
+      mail(to: application.user.email,
+           subject: 'Congratulation',
+           template_name: 'award')
+    else
+      mail(to: application.user.email,
+           subject: 'Diversity Scholarship',
+           template_name: 'decline')
+    end
   end
 
-  def decline(application)
-    @application = application
-
-    mail(to: application.user.email, subject: 'Diversity Scholarship')
-  end
 end

--- a/app/views/application_status_mailer/award.html.erb
+++ b/app/views/application_status_mailer/award.html.erb
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
-    <h1>Hi <%= @application.user.alt_name  %></h1>
-    <p>
-      Congratulation you have been granted the award!
-    </p>
-  </body>
-</html>
+<p>Dear <%= @application.user.alt_name  %></p>
+
+<p>Congratulations! I'm writing to let you know that you have been selected as a scholarship recipient of our <%= @application.cohort.title %> Turing School of Software & Design Diversity Scholarship. You’ll soon receive a credit agreement through Right Signature reflecting the additional $4,000 tuition waiver.</p>
+
+<p>We are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.</p>
+
+<p>Thank you for sharing your story with us. We hope this helps you achieve your dreams.</p>

--- a/app/views/application_status_mailer/award.html.erb
+++ b/app/views/application_status_mailer/award.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hi <%= @application.user.alt_name  %></h1>
+    <p>
+      Congratulation you have been granted the award!
+    </p>
+  </body>
+</html>

--- a/app/views/application_status_mailer/award.text.erb
+++ b/app/views/application_status_mailer/award.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @application.user.alt_name  %>
+
+Congratulation you have been granted the award!

--- a/app/views/application_status_mailer/award.text.erb
+++ b/app/views/application_status_mailer/award.text.erb
@@ -1,3 +1,7 @@
-Hi <%= @application.user.alt_name  %>
+Dear <%= @application.user.alt_name  %>
 
-Congratulation you have been granted the award!
+Congratulations! I'm writing to let you know that you have been selected as a scholarship recipient of our <%= @application.cohort.title %> Turing School of Software & Design Diversity Scholarship. You’ll soon receive a credit agreement through Right Signature reflecting the additional $4,000 tuition waiver.
+
+We are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.
+
+Thank you for sharing your story with us. We hope this helps you achieve your dreams.

--- a/app/views/application_status_mailer/decline.html.erb
+++ b/app/views/application_status_mailer/decline.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hi <%= @application.user.alt_name  %></h1>
+    <p>
+      We regret to inform you that we are unable to offer you the award.
+    </p>
+  </body>
+</html>

--- a/app/views/application_status_mailer/decline.html.erb
+++ b/app/views/application_status_mailer/decline.html.erb
@@ -1,12 +1,19 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
-    <h1>Hi <%= @application.user.alt_name  %></h1>
-    <p>
-      We regret to inform you that we are unable to offer you the award.
-    </p>
-  </body>
-</html>
+<p>
+  Dear <%= @application.user.alt_name  %>
+</p>
+
+<p>
+  I’d like to thank you for applying for the <%= @application.cohort.title %> Turing School of Software & Design Diversity Scholarship. I regret to inform you that you were not selected to receive an award.
+</p>
+
+<p>
+  Turing School received many strong applications this round. We had a very difficult time selecting scholarship recipients for this cohort because of the passion and need of each candidate.
+</p>
+
+<p>
+  We are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.
+</p>
+
+<p>
+  Thank you for sharing your story with us. We look forward to helping you achieve your dreams.
+</p>

--- a/app/views/application_status_mailer/decline.text.erb
+++ b/app/views/application_status_mailer/decline.text.erb
@@ -1,3 +1,9 @@
-Hi <%= @application.user.alt_name  %>
+Dear <%= @application.user.alt_name  %>
 
-We regret to inform you that we are unable to offer you the award.
+I’d like to thank you for applying for the <%= @application.cohort.title %> Turing School of Software & Design Diversity Scholarship. I regret to inform you that you were not selected to receive an award.
+
+Turing School received many strong applications this round. We had a very difficult time selecting scholarship recipients for this cohort because of the passion and need of each candidate.
+
+We are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.
+
+Thank you for sharing your story with us. We look forward to helping you achieve your dreams.

--- a/app/views/application_status_mailer/decline.text.erb
+++ b/app/views/application_status_mailer/decline.text.erb
@@ -1,0 +1,3 @@
+Hi <%= @application.user.alt_name  %>
+
+We regret to inform you that we are unable to offer you the award.

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,253 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'>
+    <meta content='width=device-width; initial-scale=1.0; maximum-scale=1.0;' name='viewport'>
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+    <base target='_blank'>
+    <title>Turing Email</title>
     <style>
-      /* Email styles need to be inline */
+      body *{font-family: 'Open Sans', Arial, sans-serif !important; color: #3c4040; }
+
+      div, p, a, li, td { -webkit-text-size-adjust:none; }
+
+      *{-webkit-font-smoothing: antialiased;-moz-osx-font-smoothing: grayscale;}
+      td{word-break: break-word;}
+      a{word-break: break-word; text-decoration: none; color: inherit; color: #00c2d3;}
+
+      body .ReadMsgBody
+      {width: 100%; background-color: #ffffff;}
+      body .ExternalClass
+      {width: 100%; background-color: #ffffff;}
+      body{width: 100%; height: 100%; background-color: #ffffff; margin:0; padding:0; -webkit-font-smoothing: antialiased; color: #3c4040;}
+      html{ background-color:#ffffff; width: 100%;}
+
+      body p {padding: 0!important; margin-top: 0!important; margin-right: 0!important; margin-bottom: 20px !important; margin-left: 0!important; }
+      body img {user-drag: none; -moz-user-select: none; -webkit-user-drag: none;}
+      body a.rotator img {-webkit-transition: all 1s ease-in-out;-moz-transition: all 1s ease-in-out; -o-transition: all 1s ease-in-out; -ms-transition: all 1s ease-in-out; }
+      body a.rotator img:hover { -webkit-transform: rotate(360deg); -moz-transform: rotate(360deg); -o-transform: rotate(360deg);-ms-transform: rotate(360deg); }
+      body .hover:hover {opacity:0.85;filter:alpha(opacity=85);}
+      body .jump:hover {opacity:0.75; filter:alpha(opacity=75); padding-top: 10px!important;}
+
+      body .logo img {width: 140px; height: auto;}
+      body .image110 img {width: 110px; height: auto;}
+      body .image280 img {width: 280px; height: auto;}
+      body .image600 img {width: 600px; height: auto;}
+      body .image200 img {width: 200px; height: auto;}
+      body .image185 img {width: 185px; height: auto;}
+      body .icon38 img {width: 38px; height: auto;}
+      body .smallIcon8 img {width: 8px; height: auto;}
+      body #footerIcon16 {width: 16px; height: auto;}
+    </style>
+    <style>
+      @media only screen and (max-width: 640px){
+            body body{width:auto!important;}
+            body table[class=full] {width: 100%!important; clear: both; }
+            body table[class=mobile] {width: 100%!important; padding-left: 30px; padding-right: 30px; clear: both; }
+            body table[class=fullCenter] {width: 100%!important; text-align: center!important; clear: both; }
+            body td[class=fullCenter] {width: 100%!important; text-align: center!important; clear: both; }
+            body .erase {display: none;}
+            body .buttonScale {float: none!important; text-align: center!important; display: inline-block!important; clear: both;}
+            body td[class=pad30] {width: 35px!important; clear: both;}
+            body td[class=w35] {width: 7%!important; clear: both;}
+            body .image280 img {width: 100%!important;}
+            body .image600 img {width: 100%!important;}
+            body table[class=mcenter] {width: 100%!important; text-align:center; vertical-align:middle; clear:both!important; float:none; margin: 0px!important;}
+            body td[class=h5] {height: 5px!important; clear: both;}
+          }
+    </style>
+    <style>
+      @media only screen and (max-width: 479px){
+            body body{width:auto!important;}
+            body table[class=full] {width: 100%!important; clear: both; }
+            body table[class=mobile] {width: 100%!important; padding-left: 20px; padding-right: 20px; clear: both; }
+            body table[class=fullCenter] {width: 100%!important; text-align: center!important; clear: both; }
+            body td[class=fullCenter] {width: 100%!important; text-align: center!important; clear: both; }
+            body .erase {display: none;}
+            body .buttonScale {float: none!important; text-align: center!important; display: inline-block!important; clear: both;}
+            body .eraseMob {display: none!important;}
+            body .font32 {font-size: 32px!important; line-height: 46px!important;}
+            body td[class=pad30] {width: 35px!important; clear: both;}
+            body td[class=w35] {width: 7%!important; clear: both;}
+            body .image280 img {width: 100%!important;}
+            body .image600 img {width: 100%!important;}
+            body table[class=mcenter] {text-align:center; vertical-align:middle; clear:both!important; float:none; margin: 0px!important;}
+            body td[class=h5] {height: 5px!important; clear: both;}
+          }
     </style>
   </head>
-
-  <body>
-    <%= yield %>
+  <body style='margin: 0; padding: 0;'>
+    <table align='center' bgcolor='#e3e6ea' border='0' cellpadding='0' cellspacing='0' class='full' style='padding: 20px;' width='100%'>
+      <tr>
+        <td align='center' valign='top' width='100%'>
+          <table align='center' bgcolor='#ffffff' border='0' cellpadding='0' cellspacing='0' class='full' width='100%'>
+            <tbody>
+              <tr>
+                <td align='center' valign='top' width='100%'>
+                  <table align='center' border='0' cellpadding='0' cellspacing='0' class='mobile' width='100%'>
+                    <tbody>
+                      <tr>
+                        <td align='center'>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='100%'>
+                            <tbody>
+                              <tr>
+                                <td height='70' width='100%'></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='600'>
+                            <tbody>
+                              <tr>
+                                <td align='center' width='100%'>
+                                  <!-- Centered Title -->
+                                  <table align='center' border='0' cellpadding='0' cellspacing='0' class='fullCenter' style='border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;' width='600'>
+                                    <tbody>
+                                      <tr style='text-align:center;'>
+                                        <img height='86' src='https://gallery.mailchimp.com/8080b7a05247f0dee13a0a26f/images/db2387f1-1ece-417a-9939-c2541f7b54ba.png' style='margin: 0 auto 30px auto;' width='86'>
+                                        <td height='25' width='100%'></td>
+                                      </tr>
+                                      <tr>
+                                        <td valign='middle' width='100%'>
+                                          <%= yield %>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td height='25' width='100%'></td>
+                                      </tr>
+                                      <tr>
+                                        <td align='center' width='100%'>
+                                          <table align='center' border='0' cellpadding='0' cellspacing='0' width='70'>
+                                            <tbody>
+                                              <tr>
+                                                <td align='center' bgcolor='#00C2D3' height='2' style='text-align: center; font-size: 1px; line-height: 1px; background-color: #00c2d3;' width='70'> </td>
+                                              </tr>
+                                            </tbody>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td height='25' width='100%'></td>
+                                      </tr>
+                                      <tr>
+                                        <td height='22' width='100%'></td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='100%'>
+                            <tbody>
+                              <tr>
+                                <td height='70' width='100%'></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table align='center' bgcolor='#3c4040' border='0' cellpadding='0' cellspacing='0' class='full' style='background-color: #3c4040;' width='100%'>
+            <tbody>
+              <tr>
+                <td align='center' valign='top' width='100%'>
+                  <table align='center' border='0' cellpadding='0' cellspacing='0' class='mobile' width='100%'>
+                    <tbody>
+                      <tr>
+                        <td align='center'>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='100%'>
+                            <tbody>
+                              <tr>
+                                <td height='40' width='100%'></td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='600'>
+                            <tbody>
+                              <tr>
+                                <td width='100%'>
+                                  <table align='left' border='0' cellpadding='0' cellspacing='0' class='full' style='border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;' width='450'>
+                                    <tbody>
+                                      <tr>
+                                        <td align='center' class='fullCenter' width='100%'>
+                                          <table align='left' border='0' cellpadding='0' cellspacing='0' class='fullCenter' style='border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;' width='420'>
+                                            <tbody>
+                                              <tr>
+                                                <td class='fullCenter' style="text-align: left; font-size: 14px; color: #ffffff; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 700;" width='420'>
+                                                  <a href='mailto:contact@turing.io' style='text-decoration: none; color: #ffffff;' target='_blank'>contact@turing.io</a>
+                                                </td>
+                                              </tr>
+                                            </tbody>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td height='5' style='font-size: 1px; line-height: 1px;'> </td>
+                                      </tr>
+                                      <tr>
+                                        <td align='center' class='fullCenter' style="text-align: left; font-size: 13px; color: #ffffff; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 400;" width='100%'>
+                                          © 2017 All rights Reserved
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td height='5' style='font-size: 1px; line-height: 1px;'> </td>
+                                      </tr>
+                                      <tr>
+                                        <td align='center' class='fullCenter' style="text-align: left; font-size: 13px; color: #00c2d3; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 400;" width='100%'>
+                                          <a href='https://www.turing.io' style='color: #00c2d3; text-decoration: none;' target='_blank'>turing.io</a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                  <table align='left' border='0' cellpadding='0' cellspacing='0' class='full' style='border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;' width='1'>
+                                    <tbody>
+                                      <tr>
+                                        <td height='30' width='100%'></td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                  <table align='right' border='0' cellpadding='0' cellspacing='0' class='full' style='border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;' width='130'>
+                                    <tbody>
+                                      <tr>
+                                        <td align='center' class='fullCenter' style="text-align: right; font-size: 13px; color: #ffffff; font-family: Helvetica, Arial, sans-serif, 'Open Sans'; line-height: 22px; vertical-align: top; font-weight: 400;" width='100%'>
+                                          <p style='color: #FFFFFF;'>
+                                            Turing School
+                                            <br>
+                                            <a href='https://www.google.com/maps/place/Turing+School+of+Software+%26+Design/@39.7501696,-104.9977749,17z/data=!4m5!3m4!1s0x876c78c4f77d2b15:0x3ff4c7d558d0edd1!8m2!3d39.7508006!4d-104.9965947' style='color: #ffffff; text-decoration: none;' target='_blank'>1331 17th Street  Denver, CO 80202</a>
+                                          </p>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                          <table align='center' border='0' cellpadding='0' cellspacing='0' class='full' width='100%'>
+                            <tbody>
+                              <tr>
+                                <td height='40' width='100%'></td>
+                              </tr>
+                              <tr>
+                                <td height='1' style='font-size: 1px; line-height: 1px;'> </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,19 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.sendgrid.net',
+    port:                 '587',
+    domain:               'heroku.com',
+    user_name:            ENV["SENDGRID_USERNAME"],
+    password:             ENV["SENDGRID_PASSWORD"],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,13 +20,13 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :admin do
-        resources :applications, only: [:index]
+        resources :applications, only: [:index, :update]
         resources :cohorts do
           resources :reviewers, only: [:show, :index, :update, :destroy], controller: 'cohort_reviewers'
         end
         resources :reviewers, only: [:index]
       end
-      
+
       namespace :reviewer do
         resources :cohorts, only: [:show] do
           resources :applications, only: [:show] do

--- a/spec/mailers/application_status_mailer_spec.rb
+++ b/spec/mailers/application_status_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ApplicationStatusMailer do
       assert_equal ['contact@turing.io'], email.from
       assert_equal ['somewhere@colorado.com'], email.to
 
-      award_email_text = "Dear John Galt\n\nCongratulations! I'm writing to let you know that you have been selected as a scholarship recipient of our 171 Turing School of Software & Design Diversity Scholarship. You’ll soon receive a credit agreement through Right Signature reflecting the additional $4,000 tuition waiver.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We hope this helps you achieve your dreams.\n\n"
+      award_email_text = "Dear John Galt\n\nCongratulations! I'm writing to let you know that you have been selected as a scholarship recipient of our #{application.cohort.title} Turing School of Software & Design Diversity Scholarship. You’ll soon receive a credit agreement through Right Signature reflecting the additional $4,000 tuition waiver.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We hope this helps you achieve your dreams.\n\n"
       assert_equal award_email_text, email.text_part.body.to_s
     end
 
@@ -40,7 +40,7 @@ RSpec.describe ApplicationStatusMailer do
       assert_equal ['contact@turing.io'], email.from
       assert_equal ['somewhere@colorado.com'], email.to
 
-      decline_email_text = "Dear John Galt\n\nI’d like to thank you for applying for the 171 Turing School of Software & Design Diversity Scholarship. I regret to inform you that you were not selected to receive an award.\n\nTuring School received many strong applications this round. We had a very difficult time selecting scholarship recipients for this cohort because of the passion and need of each candidate.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We look forward to helping you achieve your dreams.\n\n"
+      decline_email_text = "Dear John Galt\n\nI’d like to thank you for applying for the #{application.cohort.title} Turing School of Software & Design Diversity Scholarship. I regret to inform you that you were not selected to receive an award.\n\nTuring School received many strong applications this round. We had a very difficult time selecting scholarship recipients for this cohort because of the passion and need of each candidate.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We look forward to helping you achieve your dreams.\n\n"
       assert_equal decline_email_text, email.text_part.body.to_s
     end
   end

--- a/spec/mailers/application_status_mailer_spec.rb
+++ b/spec/mailers/application_status_mailer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationStatusMailer do
+
+  describe 'ApplicationMailer' do
+
+    it 'sends award email' do
+      application = create(:application)
+      application.status = 'awarded'
+
+      # Create the email and store it for further assertions
+      email = ApplicationStatusMailer.notify(application)
+
+      # Send the email, then test that it got queued
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      # Test the body of the sent email contains what we expect it to
+      assert_equal ['contact@turing.io'], email.from
+      assert_equal ['somewhere@colorado.com'], email.to
+      assert_equal 'Congratulation', email.subject
+    end
+
+    it 'send declined email' do
+      application = create(:application)
+      application.status = 'declined'
+
+      # Create the email and store it for further assertions
+      email = ApplicationStatusMailer.notify(application)
+
+      # Send the email, then test that it got queued
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      # Test the body of the sent email contains what we expect it to
+      assert_equal ['contact@turing.io'], email.from
+      assert_equal ['somewhere@colorado.com'], email.to
+      assert_equal 'Diversity Scholarship', email.subject
+    end
+  end
+end

--- a/spec/mailers/application_status_mailer_spec.rb
+++ b/spec/mailers/application_status_mailer_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe ApplicationStatusMailer do
       # Test the body of the sent email contains what we expect it to
       assert_equal ['contact@turing.io'], email.from
       assert_equal ['somewhere@colorado.com'], email.to
-      assert_equal 'Congratulation', email.subject
+
+      award_email_text = "Dear John Galt\n\nCongratulations! I'm writing to let you know that you have been selected as a scholarship recipient of our 171 Turing School of Software & Design Diversity Scholarship. You’ll soon receive a credit agreement through Right Signature reflecting the additional $4,000 tuition waiver.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We hope this helps you achieve your dreams.\n\n"
+      assert_equal award_email_text, email.text_part.body.to_s
     end
 
     it 'send declined email' do
@@ -37,7 +39,9 @@ RSpec.describe ApplicationStatusMailer do
       # Test the body of the sent email contains what we expect it to
       assert_equal ['contact@turing.io'], email.from
       assert_equal ['somewhere@colorado.com'], email.to
-      assert_equal 'Diversity Scholarship', email.subject
+
+      decline_email_text = "Dear John Galt\n\nI’d like to thank you for applying for the 171 Turing School of Software & Design Diversity Scholarship. I regret to inform you that you were not selected to receive an award.\n\nTuring School received many strong applications this round. We had a very difficult time selecting scholarship recipients for this cohort because of the passion and need of each candidate.\n\nWe are looking forward to having you here at Turing next month, and we are excited to be part of this next stage in your journey.\n\nThank you for sharing your story with us. We look forward to helping you achieve your dreams.\n\n"
+      assert_equal decline_email_text, email.text_part.body.to_s
     end
   end
 end

--- a/spec/mailers/previews/application_status_mailer_preview.rb
+++ b/spec/mailers/previews/application_status_mailer_preview.rb
@@ -1,0 +1,9 @@
+class ApplicationStatusMailerPreview < ActionMailer::Preview
+  def award
+    ApplicationStatusMailer.award(Application.last)
+  end
+
+  def decline
+    ApplicationStatusMailer.decline(Application.last)
+  end
+end

--- a/spec/mailers/previews/application_status_mailer_preview.rb
+++ b/spec/mailers/previews/application_status_mailer_preview.rb
@@ -1,9 +1,9 @@
 class ApplicationStatusMailerPreview < ActionMailer::Preview
   def award
-    ApplicationStatusMailer.award(Application.last)
+    ApplicationStatusMailer.notify(Application.where(status: 'awarded').last)
   end
 
   def decline
-    ApplicationStatusMailer.decline(Application.last)
+    ApplicationStatusMailer.notify(Application.where(status: 'declined').last)
   end
 end

--- a/spec/requests/api/v1/admin/applications_spec.rb
+++ b/spec/requests/api/v1/admin/applications_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe 'API::V1::Admin::CohortController' do
         params: {application: {status: 'awarded'} },
         headers: @authorization
 
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      award_email = ActionMailer::Base.deliveries.last
+
       expect(response.status).to eq(200)
       raw_application = JSON.parse(response.body)
 

--- a/spec/requests/api/v1/admin/applications_spec.rb
+++ b/spec/requests/api/v1/admin/applications_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe 'API::V1::Admin::CohortController' do
   describe 'PUT' do
 
     it 'Will update Application' do
-      # cohort = create(:cohort, :open)
       application = create(:application)
 
       put @url + '/' + application.id.to_s,

--- a/spec/requests/api/v1/admin/applications_spec.rb
+++ b/spec/requests/api/v1/admin/applications_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'API::V1::Admin::CohortController' do
+  OmniAuth.config.test_mode = true
+
+  before do
+    @url = '/api/v1/admin/applications'
+    @user = create(:user, :admin)
+
+    @token = JwToken.encode({user_id: @user.id})
+    @authorization = { 'HTTP_AUTHORIZATION' => "Bearer " + @token }
+  end
+
+
+  describe 'PUT' do
+
+    it 'Will update Application' do
+      # cohort = create(:cohort, :open)
+      application = create(:application)
+
+      put @url + '/' + application.id.to_s,
+        params: {application: {status: 'awarded'} },
+        headers: @authorization
+
+      expect(response.status).to eq(200)
+      raw_application = JSON.parse(response.body)
+
+      expect(raw_application["status"]).to eq("awarded")
+      expect(Application.last.status).to eq("awarded")
+
+    end
+  end
+
+end


### PR DESCRIPTION
Card: https://trello.com/c/xgjxv72z/466-full-circle-make-the-decline-award-actually-do-something

This sends an email (award or decline) to the applicant as well as updates the application `state`, when the admin clicks on 'Decline' button or 'Award' button.

<img width="318" alt="screen shot 2018-10-23 at 2 25 37 pm" src="https://user-images.githubusercontent.com/1551316/47360337-90c1e280-d6cf-11e8-8a5a-9bcb99000b49.png">


If the applicant has a status it will no longer show these buttons as available.

Emails are sent through our SendGrid account. 

![declineletter](https://user-images.githubusercontent.com/1551316/47360198-2f017880-d6cf-11e8-8874-b75b22ba1af0.png)
![awardletter](https://user-images.githubusercontent.com/1551316/47360200-2f9a0f00-d6cf-11e8-9ca5-ef83a03cfb2a.png)
