### PR TITLE
Reduce data requested for admin dashboard

### DIFF
--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_application/adminApplicationActionBar.js.jsx
@@ -9,11 +9,27 @@ class AdminApplicationActionBar extends React.Component {
   }
 
   showReviewers() {
-    let reviewersStatuses = this.props.application.reviews.map(review => {
-      return `${review.cohort_reviewer.user.email} - ${review.status}`
-    })
+    const options = {
+      method: 'GET',
+      headers: { 'Authorization': this.props.authorization,
+      'Content-Type': "application/json" }
+    }
 
-    alert(reviewersStatuses.join('\n'))
+    ping(`/api/v1/admin/applications/${this.props.application.id}`, options)
+    .then(response => {
+      response.json().then((json) => {
+        let reviewersStatuses = json.reviews.map(review => {
+          return `${review.cohort_reviewer.user.email} - ${review.status}`
+        })
+
+        alert(reviewersStatuses.join('\n'))
+      })
+    })
+    .catch((error) => {
+      this.props.handleAction({
+        message: 'Unable to get reviewer status'
+      })
+    })
   }
 
   updateStatus(status) {

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Admin::DashboardController < AdminController
 
   def index
-    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews => {:include => [:cohort_reviewer => {:include => :user}]}]}}, :reviewers, :non_reviewers], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
+    @cohorts = Cohort.all.to_json(:include => [{:applications => {:include => [:user, :reviews]}}, :reviewers, :non_reviewers], methods: [:formatted_close_date, :formatted_start_date, :formatted_notify_date])
     @users = User.all.to_json
     @user = current_user
     @authorization = JwToken.encode({user_id: current_user.id})

--- a/app/controllers/api/v1/admin/applications_controller.rb
+++ b/app/controllers/api/v1/admin/applications_controller.rb
@@ -7,6 +7,11 @@ class Api::V1::Admin::ApplicationsController < Api::V1::AdminApiController
                    }
   end
 
+  def show
+    application = Application.find(params[:id])
+    render json: application, :include => [:user, :reviews => {:include => [:cohort_reviewer => {:include => :user}]}], status: 200
+  end
+
   def update
     application = Application.find(params[:id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :admin do
-        resources :applications, only: [:index, :update]
+        resources :applications, only: [:index, :update, :show]
         resources :cohorts do
           resources :reviewers, only: [:show, :index, :update, :destroy], controller: 'cohort_reviewers'
         end

--- a/spec/requests/api/v1/admin/applications_spec.rb
+++ b/spec/requests/api/v1/admin/applications_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe 'API::V1::Admin::CohortController' do
     @authorization = { 'HTTP_AUTHORIZATION' => "Bearer " + @token }
   end
 
+  describe 'GET' do
+    it 'Will return one application' do
+      application = create(:application)
+
+      get @url + '/' + application.id.to_s, headers: @authorization
+
+      expect(response.status).to eq(200)
+      raw_application = JSON.parse(response.body)
+
+      expect(raw_application["id"]).to eq(application.id)
+    end
+  end
 
   describe 'PUT' do
 


### PR DESCRIPTION
With previous PR - https://github.com/turingschool/full-circle/pull/241 we were pulling too much data with `{:include => [:cohort_reviewer => {:include => :user}]}` on application.reviews. This was done to get the reviewers status on each application.

It makes more sense to just request each application only when `View Reviewers` is clicked rather than loading all this unnecessary information on dashboard load and it was driving me crazy. 

Add `show` route to Applications and return `reviewers` with `cohort_reviews` and `user`

Trello Card - https://trello.com/c/fYaeQTDp/523-update-data-requesting-for-applications
