### PR TITLE
Fix order of redirect call

### DIFF
--- a/app/controllers/concerns/authorize.rb
+++ b/app/controllers/concerns/authorize.rb
@@ -12,22 +12,26 @@ module Authorize
   end
 
   def authorize_student!
-    redirect_to root_path unless current_user
+    redirect_to root_path and return unless current_user
   end
 
   def authorize_reviewer!
-    redirect_to root_path unless current_user
-
-    unless current_user.admin? || current_user.reviewer?
-      render file: "/public/404"
+    if current_user
+      if !current_user.admin? && !current_user.reviewer?
+        render file: "/public/404"
+      end
+    else
+      redirect_to root_path unless current_user
     end
   end
 
   def authorize_admin!
-    redirect_to root_path unless current_user
-
-    unless current_user.admin?
-      render file: "/public/404"
+    if current_user
+      if !current_user.admin?
+        render file: "/public/404"
+      end
+    else
+      redirect_to root_path unless current_user
     end
   end
 


### PR DESCRIPTION
According to rails docs:

Statements after `redirect_to` in our controller get executed, so `redirect_to` doesn't stop the execution of the function. To terminate the execution of the function immediately after the `redirect_to`, use return.

So changed the order of if statement to no longer execute code after the redirect.