### PR TITLE
Sort apps by score with uncompleted warning

### DIFF
--- a/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplicationsList.js.jsx
+++ b/app/assets/javascripts/components/admin/view_cohorts_page/view_cohorts/adminCohortApplicationsList.js.jsx
@@ -6,7 +6,10 @@ class AdminCohortApplicationList extends React.Component {
         {this.props.applications.map((app) => {
           return <SelectableTextField
             key={app.user.id}
-            texts={[`${app.totalAverage || 0} (${app.numberOfReviews}/${app.reviews.length})`, app.user.email, app.state]}
+            texts={[
+              { displayText: `${app.totalAverage || 0} (${app.numberOfReviews}/${app.reviews.length})`, classes: app.numberOfReviews != app.reviews.length ? 'warning' : ''},
+              { displayText: app.user.email},
+              { displayText: app.state}]}
             width='100%'
             returnKey='application'
             returnValue={app}

--- a/app/assets/javascripts/components/reviewer/view_applications_page/view_cohorts/reviewerCohortApplicationsList.js.jsx
+++ b/app/assets/javascripts/components/reviewer/view_applications_page/view_cohorts/reviewerCohortApplicationsList.js.jsx
@@ -1,5 +1,5 @@
 class ReviewerCohortApplicationList extends React.Component {
-  
+
   reviewStatus(app) {
     if (this.findUserReview(app)) {
       return this.findUserReview(app).status
@@ -7,7 +7,7 @@ class ReviewerCohortApplicationList extends React.Component {
       return "N/A"
     }
   }
-  
+
   totalScore(app) {
     if (this.findUserReview(app)) {
       return this.findUserReview(app).score_card.total
@@ -15,7 +15,7 @@ class ReviewerCohortApplicationList extends React.Component {
       return "N/A"
     }
   }
-  
+
   findUserReview(app){
     return app.reviews.find((review) => {
       return this.props.user.cohort_reviewers.some((cohort_reviewer) => {
@@ -35,7 +35,7 @@ class ReviewerCohortApplicationList extends React.Component {
         {this.props.applications.map((app) => {
           return <SelectableTextField
             key={app.id}
-            texts={[app.id, this.reviewStatus(app), this.totalScore(app)]}
+            texts={[{ displayText: app.id}, { displayText: this.reviewStatus(app)}, { displayText: this.totalScore(app)}]}
             width='100%'
             application={this.props.application}
             returnKey='application'

--- a/app/assets/javascripts/components/shared/selectableTextField.js.jsx
+++ b/app/assets/javascripts/components/shared/selectableTextField.js.jsx
@@ -2,7 +2,7 @@ class SelectableTextField extends React.Component {
 
   constructor(props) {
     super(props)
-  
+
     this.state = {
       application: this.props.application
     }
@@ -15,7 +15,7 @@ class SelectableTextField extends React.Component {
     obj['finalizingMessage'] = ''
     return obj
   }
-  
+
   onItemClick(event) {
     [].slice.call(event.currentTarget.parentElement.parentElement.children).forEach((child) => {
       child.children[0].style.backgroundColor = 'transparent';
@@ -25,14 +25,15 @@ class SelectableTextField extends React.Component {
       this.returnObject()
     )
   }
-  
+
   highlightApplication() {
     if (this.props.returnValue == this.props.application) {
       return (<div className='selectable-text-field'
         style={{width: this.props.width, backgroundColor: 'rgba(200, 200, 200, 0.4)'}}
         onClick={this.onItemClick.bind(this)}>
         {this.props.texts.map((text) => {
-          return <span key={text}>{text}</span>
+          let {displayText, classes} = text
+          return <span key={displayText} className={classes}>{displayText}</span>
         })}
       </div>
       )
@@ -41,7 +42,8 @@ class SelectableTextField extends React.Component {
         style={{width: this.props.width}}
         onClick={this.onItemClick.bind(this)}>
         {this.props.texts.map((text) => {
-          return <span key={text}>{text}</span>
+          let {displayText, classes} = text
+          return <span key={displayText} className={classes}>{displayText}</span>
         })}
       </div>
       )

--- a/app/assets/javascripts/helpers/application.js.jsx
+++ b/app/assets/javascripts/helpers/application.js.jsx
@@ -1,9 +1,9 @@
 function sortedWithReviewCount(applications) {
   appsWithScore = applications.map(application => Object.assign(application, scoreAndReviewers(application)))
   return appsWithScore.sort((a,b) => {
-    if ((a.state === "draft" && b.state === "submitted") || a.numberOfReviews < b.numberOfReviews) {
+    if (a.state === "draft" && b.state === "submitted") {
       return 1;
-    } else if ((a.state === "submitted" && b.state === "draft") || a.numberOfReviews > b.numberOfReviews) {
+    } else if (a.state === "submitted" && b.state === "draft") {
       return -1;
     } else {
       return b.totalAverage - a.totalAverage
@@ -22,5 +22,8 @@ function scoreAndReviewers(application) {
     }
   })
 
-  return {numberOfReviews, totalAverage: parseFloat((totalSum/numberOfReviews).toFixed(2))}
+  let totalAverage = parseFloat((totalSum/numberOfReviews).toFixed(2))
+  if (isNaN(totalAverage)) { totalAverage = 0 }
+
+  return {numberOfReviews, totalAverage}
 }

--- a/app/assets/stylesheets/pages/_all.scss
+++ b/app/assets/stylesheets/pages/_all.scss
@@ -5,3 +5,7 @@
   margin-bottom: 10px;
   font-size: 30px;
 }
+
+.warning {
+  color: $action-red;
+}


### PR DESCRIPTION
On the admin side applications were being sorted by the number of reviews rather than by score. This made it difficult to see the correct winner.

Now sort by the score but show the score with a red warning if all the reviewers assigned to the application haven't reviewed the app. This should give more insight into having the correct number of reviews and the winners.