### PR TITLE
Reroute on timeout cl

### DIFF
--- a/app/assets/javascripts/components/student/studentDashboard.js.jsx
+++ b/app/assets/javascripts/components/student/studentDashboard.js.jsx
@@ -54,7 +54,7 @@ class StudentDashboard extends React.Component {
       headers: { 'Authorization': this.authorization }
     }
 
-    fetch('/api/v1/student/applications' + params, options)
+    ping('/api/v1/student/applications' + params, options)
       .then((data) => {
         return data.json()
       })

--- a/app/assets/javascripts/ping/ping.js.jsx
+++ b/app/assets/javascripts/ping/ping.js.jsx
@@ -7,6 +7,10 @@ function ping(url, options) {
 }
 
 function handleErrors(response) {
+  if (response.status === 401) {
+    window.alert('Session Expired. Please Log In.')
+    window.location.assign('/')
+  }
   if (!response.ok) {
     throw response
   }

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -11,7 +11,7 @@ module ErrorHandler
 
       rescue_from JWT::DecodeError do |error|
         Honeybadger.notify("JWT::DecodeError", context: {error: error})
-        render json: { "error"=>"JWT::DecodeError - Forbidden" }, status: 403
+        render json: { "error"=>"JWT::DecodeError - Forbidden" }, status: 401
       end
     end
   end

--- a/spec/requests/api/v1/admin/cohorts_controller_spec.rb
+++ b/spec/requests/api/v1/admin/cohorts_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'API::V1::Admin::CohortController' do
     it 'Will return Forbidden if invalid token is sent' do
       get @url, headers: { 'HTTP_AUTHORIZATION' => "Bearer " + '1' }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(401)
       expect(JSON.parse(response.body)).to eq({ "error"=>"JWT::DecodeError - Forbidden" })
     end
 

--- a/spec/requests/api/v1/admin/reviewers_spec.rb
+++ b/spec/requests/api/v1/admin/reviewers_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'API::V1::Admin::ReviewersController' do
     it 'Will return Forbidden if invalid token is sent' do
       get url, headers: { 'HTTP_AUTHORIZATION' => "Bearer " + '1' }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(401)
       expect(JSON.parse(response.body)).to eq({ "error"=>"JWT::DecodeError - Forbidden" })
     end
 

--- a/spec/requests/api/v1/student/applications_controller_spec.rb
+++ b/spec/requests/api/v1/student/applications_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'API::V1::Student::ApplicationController' do
     it 'Will return Forbidden if invalid token is sent' do
       get @url, headers: { 'HTTP_AUTHORIZATION' => "Bearer " + '1' }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(401)
       expect(JSON.parse(response.body)).to eq({ "error"=>"JWT::DecodeError - Forbidden" })
     end
   end

--- a/spec/requests/api/v1/student/users_controller_spec.rb
+++ b/spec/requests/api/v1/student/users_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'API::V1::Student::UserController' do
     it 'Will return Forbidden if invalid token is sent' do
       put @url, headers: { 'HTTP_AUTHORIZATION' => "Bearer " + '1' }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(401)
       expect(JSON.parse(response.body)).to eq({ "error"=>"JWT::DecodeError - Forbidden" })
     end
   end


### PR DESCRIPTION
https://trello.com/c/TjxjXwhy/591-full-circle-redirect-user-to-log-in-page-on-unauthorized
Changed the response status to 401 when the user's token has expired. Added an alert to notify the user that their session had expired and they need to login again. Also redirects user to the index page so they may login again. Changed status codes in specs to 401 if an invalid token is sent.