### PR TITLE
Replace SendGrid with Postmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'omniauth'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
 gem 'omniauth-github'
 gem 'pg', '~> 0.18'
+gem 'postmark-rails'
 gem 'puma', '~> 3.12'
 gem 'rails', '~> 5.2.2'
 gem 'react-rails', '~> 2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,11 @@ GEM
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
+    postmark (1.21.1)
+      json
+    postmark-rails (0.20.0)
+      actionmailer (>= 3.0.0)
+      postmark (~> 1.15)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -290,6 +295,7 @@ DEPENDENCIES
   pg (~> 0.18)
   phantomjs (~> 2.0)
   poltergeist
+  postmark-rails
   pry-rails
   puma (~> 3.12)
   rails (~> 5.2.2)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,17 +66,9 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
 
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.smtp_settings = {
-    address:              'smtp.sendgrid.net',
-    port:                 '587',
-    domain:               'heroku.com',
-    user_name:            ENV["SENDGRID_USERNAME"],
-    password:             ENV["SENDGRID_PASSWORD"],
-    authentication:       'plain',
-    enable_starttls_auto: true
-  }
+  # Set up transactional emails through Postmark
+  config.action_mailer.delivery_method = :postmark
+  config.action_mailer.postmark_settings = { api_token: Rails.application.secrets.postmark_api_token }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,3 +30,4 @@ test:
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  postmark_api_token: <%= ENV['POSTMARK_API_TOKEN'] %>


### PR DESCRIPTION
#### What does this PR do?
- Replaces Sendgrid with Postmark

#### Where should the reviewer start?
It's pretty short but `config/environments/production.rb`

#### How should this be manually tested?

#### Any background context you want to provide?
We started getting blocked from sending emails to @hotmail and @outlook accounts when using Sendgrid. It is likely that we are in shared email pools that may have been sending spam.

#### What are the relevant tickets?
https://trello.com/c/aZ6Oambp/867-getting-block-by-hotmail-outlook-on-emails-over-sendgrid

#### Questions:
  - Do Migrations Need to be ran? No
  - Do Environment Variables need to be set? `POSTMARK_API_TOKEN`
  - Any other deploy steps? No
