### PR TITLE
Change bcc for application status email

### DIFF
--- a/app/mailers/application_status_mailer.rb
+++ b/app/mailers/application_status_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationStatusMailer < ApplicationMailer
 
     mail(
         to: @application.user.email,
-        bcc: "contact@turing.io",
+        bcc: "darren@turing.io",
         subject: "Turing School Scholarship Application",
         template_name: application.status == 'awarded' ? "award" : "decline"
         )


### PR DESCRIPTION
To darren@turing.io

Resolves https://trello.com/c/QIwzzFdk/962-cc-darrenturingio-on-award-decline-emails